### PR TITLE
Update active_zuora.gemspec

### DIFF
--- a/active_zuora.gemspec
+++ b/active_zuora.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = [ "README.md" ]
 
   s.add_runtime_dependency('savon', ["~> 1.2.0"])
-  s.add_runtime_dependency('activesupport', [">= 3.0.0", "< 5.1.0"])
-  s.add_runtime_dependency('activemodel', [">= 3.0.0", "< 5.1.0"])
+  s.add_runtime_dependency('activesupport', [">= 3.0.0", "< 6.0"])
+  s.add_runtime_dependency('activemodel', [">= 3.0.0", "< 6.0"])
 
   s.add_development_dependency('rake', [">= 0.8.7"])
   s.add_development_dependency('rspec', [">= 3.0.0"])


### PR DESCRIPTION
I would like to use this gem on a rails 5.1 branch. Based on a local branch I believe that updating the dependencies for activesupport and activemodel should suffice.